### PR TITLE
Support Markdown table rendering to Wordpress html using Tables extension

### DIFF
--- a/src/wordpress_markdown_blog_loader/blog.py
+++ b/src/wordpress_markdown_blog_loader/blog.py
@@ -207,7 +207,7 @@ class Blog(object):
             return match.group(0)
 
         content = self.markdown_image_pattern.sub(replace_references, self.content)
-        return markdown(content, extensions=["fenced_code", "attr_list"])
+        return markdown(content, extensions=["fenced_code", "attr_list", "tables"])
 
     @property
     def local_image_references(self) -> set[str]:
@@ -391,6 +391,7 @@ class Blog(object):
             MARKDOWN_EXTENSIONS=[
                 "markdown.extensions.fenced_code",
                 "markdown.extensions.extra",
+                "markdown.extensions.tables",
             ],
             code_language_callback=_code_block_language,
         )

--- a/tests/resources/tables.md
+++ b/tests/resources/tables.md
@@ -1,0 +1,15 @@
+---
+author: Laurens Knoll
+status: publish
+date: 2020-02-15 23:21:00+01:00
+slug: try-this-one
+status: publish
+title: Tables
+subtitle: Testing markdown tables extension
+---
+
+## Table
+
+| Col A | Col B |
+|:---- | --- |
+| Hello | World |

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1,0 +1,19 @@
+
+import os
+import unittest
+
+from wordpress_markdown_blog_loader.blog import Blog
+
+class Test_BlogRender(unittest.TestCase):
+    def test_tables(self):
+        path = os.path.join(os.path.dirname(__file__), "resources", "tables.md")
+        blog = Blog.load(path)
+        self.assertIsNotNone(blog.rendered)
+        self.assertIn('<table>', blog.rendered)
+        self.assertIn('<thead>', blog.rendered)
+        self.assertIn('<th>Col B</th>', blog.rendered)
+        self.assertIn('<tbody>', blog.rendered)
+        self.assertIn('<td style="text-align: left;">Hello</td>', blog.rendered)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Include the 'tables' extension in the list of extension;
Add a unit test to verify that a markdown table is rendered using <thead><tbody> tags.