### PR TITLE
Find unique user based on lowercase email compare

### DIFF
--- a/src/wordpress_markdown_blog_loader/api.py
+++ b/src/wordpress_markdown_blog_loader/api.py
@@ -343,6 +343,7 @@ class Wordpress(object):
                 raise ValueError(
                     f"Multiple authors named '{name}' found, none with email {email} (possible: { {u.email for u in users} })."
                 )
+            return user
         return users[0]
 
     def posts(self, query: dict = None) -> Iterator["Post"]:

--- a/src/wordpress_markdown_blog_loader/api.py
+++ b/src/wordpress_markdown_blog_loader/api.py
@@ -338,10 +338,10 @@ class Wordpress(object):
         if len(users) == 0:
             raise ValueError(f"author '{name}' not found on {self.endpoint.host}")
         elif len(users) > 1:
-            user = next(filter(lambda u: email and u.email == email, users), None)
+            user = next(filter(lambda u: email and u.email.lower() == email.lower(), users), None)
             if not user:
                 raise ValueError(
-                    f"Multiple authors named '{name}' found, none with email {email}"
+                    f"Multiple authors named '{name}' found, none with email {email} (possible: { {u.email for u in users} })."
                 )
         return users[0]
 


### PR DESCRIPTION
When multiple users are found, do email check case-insensitive. 
In case the email does not match, log the found email address as a set.
Return the user which matches the email address instead of the first in the list.

Fix for #11 