### PR TITLE
feat: embed audio players from local sound files via ::: audio directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ in your favorite editor and keeps all your blogs in git.
 ## features
 - converts markdown into plain html, with syntax hightlighting support
 - uploads and synchronizes any locally referenced images
+- embeds audio players from locally referenced sound files
 - generates an opengraph image including the title, subtitle and author in Binx.io or xebia.com style
 - sets the Rankmath focus keywords
 - sets the canonical url, if specified
@@ -121,6 +122,21 @@ To add an image to your blog, add the images in the ./images subdirectory and ad
 ```markdown
 ![](./images/architecture.png)
 ```
+
+## adding audio
+To embed an audio player, add the sound file in a subdirectory (for example `./audio`)
+and add an `::: audio` directive on its own line, with a relative reference. For instance:
+
+```markdown
+## Listen to this section
+
+::: audio ./audio/section-one.mp3
+```
+
+The sound file is uploaded and synchronized just like an image, and rendered as a native
+Wordpress audio block (a player with controls) at that position. Drop one directive under
+each heading to give every section its own player. Remote URLs (`https://...`) are embedded
+as-is without uploading.
 
 ## uploading a blog
 To upload a blog, type:

--- a/src/wordpress_markdown_blog_loader/blog.py
+++ b/src/wordpress_markdown_blog_loader/blog.py
@@ -29,8 +29,13 @@ class Blog(object):
         self.path: Path = None
         self.blog: frontmatter.Post = frontmatter.Post(content="")
         self.uploaded_images: dict[str, Media] = {}
+        self.uploaded_audio: dict[str, Medium] = {}
         self.markdown_image_pattern = re.compile(
             r'\!\[(?P<alt_text>[^]]*)\]\((?P<url>.*?)(?P<caption>\s*"[^"]*?")?\)'
+        )
+        # An audio player directive on its own line: `::: audio path/to/clip.mp3`
+        self.audio_directive_pattern = re.compile(
+            r"^[ \t]*:::[ \t]+audio[ \t]+(?P<url>\S+)[ \t]*$", re.MULTILINE
         )
 
     @staticmethod
@@ -306,7 +311,19 @@ class Blog(object):
                 return f"![{match.group('alt_text')}]({image.url}{caption})"
             return match.group(0)
 
+        def replace_audio_directive(match: re.Match):
+            url = match.group("url")
+            audio = self.uploaded_audio.get(url)
+            src = audio.url if audio else url
+            # raw block-level HTML; python-markdown passes it through untouched,
+            # and html_to_gutenberg turns it into a wp:audio block.
+            return (
+                f'<figure class="wp-block-audio">'
+                f'<audio controls src="{src}"></audio></figure>'
+            )
+
         content = self.markdown_image_pattern.sub(replace_references, self.content)
+        content = self.audio_directive_pattern.sub(replace_audio_directive, content)
         html = markdown(
             content, extensions=["fenced_code", "attr_list", "tables", "footnotes"],
         )
@@ -395,9 +412,41 @@ class Blog(object):
             slug = self.slug + "-" + re.sub(r"[/\.\\]+", "-", path.stem.strip("-"))
             self.uploaded_images[filename] = wp.upload_media(slug, path)
 
+    @property
+    def local_audio_references(self) -> set[str]:
+        """
+        Local audio files referenced by `::: audio <path>` directives.
+
+        >>> b = Blog()
+        >>> b.content = "## H\\n\\n::: audio images/clip.mp3\\n\\ntext\\n"
+        >>> sorted(b.local_audio_references)
+        ['images/clip.mp3']
+        """
+        return set(
+            filter(
+                lambda u: urlparse(u).scheme in ["", "file"],
+                map(
+                    lambda m: m.group("url"),
+                    re.finditer(self.audio_directive_pattern, self.content),
+                ),
+            )
+        )
+
+    def upload_local_audio(self, wp: Wordpress):
+        self.uploaded_audio = {}
+        for filename in self.local_audio_references:
+            path = Path(self.dir).joinpath(filename)
+            if not path.exists():
+                logging.warning("%s does not exist", path)
+                continue
+
+            slug = self.slug + "-" + re.sub(r"[/\.\\]+", "-", path.stem.strip("-"))
+            self.uploaded_audio[filename] = wp.upload_media(slug, path)
+
     def to_wordpress(self, wp: Wordpress) -> dict:
         author = wp.get_unique_user_by_name(self.author, self.email, self.author_id)
         self.upload_local_images(wp)
+        self.upload_local_audio(wp)
         result = {
             "title": self.title,
             "slug": self.slug,

--- a/src/wordpress_markdown_blog_loader/html_to_gutenberg.py
+++ b/src/wordpress_markdown_blog_loader/html_to_gutenberg.py
@@ -14,6 +14,10 @@ def _wrap_in_gutenberg_comments(element):
         return _wrap_list(element)
     if element.name == "img":
         return _wrap_image(element)
+    if element.name == "figure" and "wp-block-audio" in element.get("class", []):
+        return _wrap_audio(element)
+    if element.name == "audio":
+        return _wrap_audio(element)
     if element.name == "blockquote":
         return _wrap_quote(element)
     return str(element)
@@ -84,6 +88,24 @@ def _wrap_list(element):
 
 def _wrap_image(element):
     return f"<!-- wp:image -->\n{str(element)}\n<!-- /wp:image -->"
+
+
+def _wrap_audio(element):
+    """
+    Wrap an audio element in a wp:audio Gutenberg block. Accepts either a bare
+    <audio> tag or a <figure class="wp-block-audio"> already wrapping one, and
+    always emits the figure form Wordpress expects.
+
+    >>> from bs4 import BeautifulSoup
+    >>> soup = BeautifulSoup('<audio controls src="https://x/c.mp3"></audio>', "html.parser")
+    >>> _wrap_audio(soup.audio)
+    '<!-- wp:audio -->\\n<figure class="wp-block-audio"><audio controls="" src="https://x/c.mp3"></audio></figure>\\n<!-- /wp:audio -->'
+    """
+    audio = element if element.name == "audio" else element.find("audio")
+    figure = (
+        f'<figure class="wp-block-audio">{str(audio)}</figure>' if audio else str(element)
+    )
+    return f"<!-- wp:audio -->\n{figure}\n<!-- /wp:audio -->"
 
 
 def convert(title, html_body):

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -15,5 +15,38 @@ class Test_BlogRender(unittest.TestCase):
         self.assertIn('<tbody>', blog.rendered)
         self.assertIn('<td style="text-align: left;">Hello</td>', blog.rendered)
 
+
+class Test_AudioDirective(unittest.TestCase):
+    def _blog(self, content):
+        blog = Blog()
+        blog.title = "Audio post"
+        blog.content = content
+        return blog
+
+    def test_local_audio_references(self):
+        blog = self._blog(
+            "## One\n\n::: audio images/clips/a.mp3\n\ntext\n\n"
+            "## Two\n\n::: audio images/clips/b.wav\n\nmore\n"
+        )
+        self.assertEqual(
+            blog.local_audio_references,
+            {"images/clips/a.mp3", "images/clips/b.wav"},
+        )
+
+    def test_remote_audio_not_collected_as_local(self):
+        blog = self._blog("::: audio https://cdn.example.com/a.mp3\n")
+        self.assertEqual(blog.local_audio_references, set())
+
+    def test_rendered_directive_becomes_audio_block(self):
+        # without an uploaded URL it falls back to the raw path (local preview)
+        blog = self._blog("## Section\n\n::: audio images/clips/a.mp3\n\ntext\n")
+        rendered = blog.rendered
+        self.assertIn("<!-- wp:audio -->", rendered)
+        self.assertIn('<figure class="wp-block-audio">', rendered)
+        self.assertIn('src="images/clips/a.mp3"', rendered)
+        # the directive line must not leak through as a paragraph
+        self.assertNotIn("::: audio", rendered)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_html_to_gutenberg.py
+++ b/tests/test_html_to_gutenberg.py
@@ -8,6 +8,7 @@ from wordpress_markdown_blog_loader.html_to_gutenberg import (
     _wrap_pre,
     _wrap_list,
     _wrap_image,
+    _wrap_audio,
     _wrap_in_gutenberg_comments,
     _wrap_quote,
     convert,
@@ -76,6 +77,31 @@ class TestGutenbergWrapFunctions(unittest.TestCase):
         self.assertTrue(res.startswith("<!-- wp:image -->"))
         self.assertIn('<img alt="desc" src="img.png"/>', res)
         self.assertTrue(res.endswith("<!-- /wp:image -->"))
+
+    def test_wrap_audio_from_bare_tag(self):
+        soup = BeautifulSoup(
+            '<audio controls src="https://x/c.mp3"></audio>', "html.parser"
+        )
+        res = _wrap_audio(soup.audio)
+        self.assertTrue(res.startswith("<!-- wp:audio -->"))
+        self.assertIn('<figure class="wp-block-audio">', res)
+        self.assertIn('src="https://x/c.mp3"', res)
+        self.assertIn("<audio", res)
+        self.assertTrue(res.endswith("<!-- /wp:audio -->"))
+
+    def test_wrap_audio_from_figure(self):
+        html = '<figure class="wp-block-audio"><audio controls src="https://x/c.mp3"></audio></figure>'
+        soup = BeautifulSoup(html, "html.parser")
+        res = _wrap_audio(soup.figure)
+        self.assertTrue(res.startswith("<!-- wp:audio -->"))
+        self.assertIn('<figure class="wp-block-audio">', res)
+        self.assertIn('src="https://x/c.mp3"', res)
+
+    def test_wrap_in_gutenberg_comments_routes_audio_figure(self):
+        html = '<figure class="wp-block-audio"><audio controls src="https://x/c.mp3"></audio></figure>'
+        soup = BeautifulSoup(html, "html.parser")
+        res = _wrap_in_gutenberg_comments(soup.figure)
+        self.assertTrue(res.startswith("<!-- wp:audio -->"))
 
     def test_wrap_in_gutenberg_comments_with_comment(self):
         comment = Comment(" a comment ")
@@ -156,6 +182,18 @@ class TestConvertFunction(unittest.TestCase):
         self.assertIn("<!-- wp:paragraph -->", result)
         self.assertIn("<!-- wp:heading -->", result)
         self.assertIn("<!-- wp:code -->", result)
+
+    def test_convert_with_audio(self):
+        title = "Audio"
+        html_body = (
+            '<h2>Section</h2>'
+            '<figure class="wp-block-audio">'
+            '<audio controls src="https://x/c.mp3"></audio></figure>'
+        )
+        result = convert(title, html_body)
+        self.assertIn("<!-- wp:heading -->", result)
+        self.assertIn("<!-- wp:audio -->", result)
+        self.assertIn('<figure class="wp-block-audio">', result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds support for a `::: audio <path>` markdown directive that renders a native WordPress audio block (a player with controls) at that position in the post.

```markdown
## Listen to this section

::: audio ./images/clips/section-one.mp3
```

This makes it possible to give each section of a post its own player — e.g. for narrated blog posts — without hand-writing raw HTML that the loader would otherwise strip.

## How

It mirrors the existing image flow:

- **`blog.py`**
  - `audio_directive_pattern` — matches `::: audio <path>` on its own line
  - `local_audio_references` — collects local audio paths (skips remote `http(s)` URLs)
  - `upload_local_audio()` — uploads each file via the existing mime-aware `upload_media` (works for `.mp3`/`.wav`/etc. with no changes), called from `to_wordpress`
  - in `rendered`, each directive is rewritten to a `<figure class="wp-block-audio">` with the uploaded URL (falling back to the raw path for local preview)
- **`html_to_gutenberg.py`**
  - `_wrap_audio()` emits a `<!-- wp:audio -->` block; `_wrap_in_gutenberg_comments` routes audio `<figure>`/`<audio>` elements to it
- **Remote URLs** are embedded as-is without uploading.

## Tests

- New unit tests in `tests/test_html_to_gutenberg.py` and `tests/test_blog.py`
- New doctests in `blog.py` and `html_to_gutenberg.py`
- `make test` passes (22 unit tests + doctests)

## Docs

- README: new feature bullet + an "adding audio" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)